### PR TITLE
Update ChatGPT user-message selector and bump version to 1.9.1

### DIFF
--- a/chat-toc.cn.user.js
+++ b/chat-toc.cn.user.js
@@ -3,7 +3,7 @@
 // @description     Add a draggable Table of Contents for common AI websites.
 // @updateURL       https://gitee.com/ericwvi/chat-toc/raw/main/chat-toc.cn.user.js
 // @downloadURL     https://gitee.com/ericwvi/chat-toc/raw/main/chat-toc.cn.user.js
-// @version         1.9.0
+// @version         1.9.1
 // @author          Eric Wang
 // @namespace       ChatTOC
 // @copyright       2025, Eric Wang (https://github.com/EricWvi)
@@ -68,9 +68,7 @@
     // Define strategies for different hosts
     const strategies = {
         'chatgpt.com': function () {
-            return [...document.querySelectorAll('article')]
-                .filter((_, idx) => idx % 2 == 0)
-                .map(article => article.querySelector('div'));
+            return [...document.querySelectorAll('[data-message-author-role="user"]')];
         },
         'gemini.google.com': function () {
             return [...document.querySelectorAll('user-query-content .query-text')];

--- a/chat-toc.user.js
+++ b/chat-toc.user.js
@@ -3,7 +3,7 @@
 // @description     Add a draggable Table of Contents for common AI websites.
 // @updateURL       https://raw.githubusercontent.com/EricWvi/chat-toc/main/chat-toc.user.js
 // @downloadURL     https://raw.githubusercontent.com/EricWvi/chat-toc/main/chat-toc.user.js
-// @version         1.9.0
+// @version         1.9.1
 // @author          Eric Wang
 // @namespace       ChatTOC
 // @copyright       2025, Eric Wang (https://github.com/EricWvi)
@@ -68,9 +68,7 @@
     // Define strategies for different hosts
     const strategies = {
         'chatgpt.com': function () {
-            return [...document.querySelectorAll('article')]
-                .filter((_, idx) => idx % 2 == 0)
-                .map(article => article.querySelector('div'));
+            return [...document.querySelectorAll('[data-message-author-role="user"]')];
         },
         'gemini.google.com': function () {
             return [...document.querySelectorAll('user-query-content .query-text')];


### PR DESCRIPTION
### Motivation
- Replace a fragile `article`-based traversal on `chatgpt.com` with a direct selector for user messages (`data-message-author-role="user"`) and publish the patch as `1.9.1`.

### Description
- Modified the `chatgpt.com` scraping strategy in both `chat-toc.user.js` and `chat-toc.cn.user.js` to use `document.querySelectorAll('[data-message-author-role="user"]')` instead of selecting and filtering `article` elements, and updated the script `@version` to `1.9.1` in both files.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cce3346bc08333bc3f23a4b3492de5)